### PR TITLE
Remove errant </div> from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,6 @@ For Puppet Enterprise, the default directory is */etc/puppetlabs/puppet/modules*
     git clone https://github.com/loggly/loggly-puppet.git loggly
 
 You've now installed the Loggly module into your module path.
-</div>
 ----
 
 ## Finding your Customer Token


### PR DESCRIPTION
There was a stray closing div tag in the README that caused a
rendering failure on the forge.puppetlabs.com module page. Removing
that tag should be meaningless for the REAMDE and correct the bug
on Forge.

Thanks for publishing your module to the Forge! Sorry for the trouble. Once you release a version with this patch, the module page should look as we intend it. For the future, we'll also update the Forge to not bug out when we get an errant tag like this.
