### PR TITLE
Ensure that SSL certificates are in place before restarting rsyslog

### DIFF
--- a/manifests/rsyslog.pp
+++ b/manifests/rsyslog.pp
@@ -61,7 +61,7 @@ class loggly::rsyslog (
 
         # Add a dependency on the rsyslog-gnutls package to the configuration
         # snippet so that it will be installed before we generate any config
-        File['/etc/rsyslog.d/22-loggly.conf'] -> Package['rsyslog-gnutls']
+        Class['loggly'] -> File['/etc/rsyslog.d/22-loggly.conf'] -> Package['rsyslog-gnutls']
     }
 
     # Call an exec to restart the syslog service instead of using a puppet


### PR DESCRIPTION
There is currently no dependency on the SSL certificate being installed prior to the rsyslog daemon being restarted. If the daemon is restarted without the SSL cert in place, rsyslog will fail to load the gnutls extension (and no logs get sent to Loggly).

Tested on RHEL 6.5/rsyslog 5.8.10.