### PR TITLE
Fix typo in project_page by separating loggly and puppet with a dash

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -4,7 +4,7 @@ author 'loggly'
 license 'Apache License, Version 2.0'
 summary 'Configures various data sources for automatic submission to Loggly'
 description 'This puppet module allows various data sources to be configured for automatic submission to Loggly, such as rsyslog, sylog-ng, Apache, PHP, Ruby, etc.'
-project_page 'https://github.com/loggly/logglypuppet'
+project_page 'https://github.com/loggly/loggly-puppet'
 
 ## Add dependencies, if any:
 # dependency 'username/name', '>= 1.2.0'


### PR DESCRIPTION
Add the dash so the project url on the Forge page points to the right place.