### PR TITLE
Correctly declare variables with @

### DIFF
--- a/templates/log.conf.erb
+++ b/templates/log.conf.erb
@@ -2,11 +2,11 @@
 $ModLoad imfile
 $InputFilePollInterval 10
 
-#<%= logname %>
-$InputFileName <%= filepath %>
-$InputFileTag <%= logname %>:
-$InputFileStateFile stat-<%= logname %>-log
-$InputFileSeverity <%= severity %>
+#<%= @logname %>
+$InputFileName <%= @filepath %>
+$InputFileTag <%= @logname %>:
+$InputFileStateFile stat-<%= @logname %>-log
+$InputFileSeverity <%= @severity %>
 $InputRunFileMonitor
 
 


### PR DESCRIPTION
Puppet complains about deprecated bare variables in log.conf.erb. This just adds the '@' to the variables.